### PR TITLE
[FEAT] docker, nginx 설정 #36

### DIFF
--- a/react/Dockerfile
+++ b/react/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine as builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/react/docker-compose.yml
+++ b/react/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  frontend:
+    container_name: frontend
+    build:
+      context: ./react
+      dockerfile: Dockerfile
+    ports:
+      - "80:80"
+    restart: always
+    networks:
+      - the-labot-network
+
+networks:
+ the-labot-network:
+    external: true

--- a/react/nginx.conf
+++ b/react/nginx.conf
@@ -1,0 +1,20 @@
+server{
+	listen 80;
+
+	location / {
+		root /usr/share/nginx/html; # 파일을 어디서 찾을까
+		index index.html index.htm; # 사용자가 파일명을 지정하지 않았을 때 기본으로 보여줄 파일
+		try_files $uri $uri/ /index.html; # SPA 필수 설정. 요청한 파일 있으면 그걸 주고 없으면 폴더 확인해보고 그래도 없으면 기본 보여줘
+	}
+
+	location /api/{
+		proxy_pass http://backend:8080;
+		
+		# 그냥 넘기면 백엔드 입장에선 요청 보낸 사람이 nginx(도커 내부 ip로 보임)
+		# 그래서 원래 요청한 사람의 진짜 정보는 이거다 라고 꼬리표(Header)를 붙여서 보냄 그래야 로그에 진짜 사용자 ip 찍힘
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $scheme;
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#36 
## 📝작업 내용

Dockerfile, docker-compse.yml, nginx.conf 파일 생성했습니다.

### Dockerfile
의존성 및 빌드 파일 COPY, 80포트 EXPOSE
nginx설정 복사
(ec2에 docker network 생성)

### docker-compose.yml
EC2의 80 포트와 컨테이너의 80 포트 연결.

### nginx.conf
80 받고 정적이면 빌드한 정적파일 처리, api면 백엔드로 넘김
